### PR TITLE
replaces all versions of nodejs to 10.x

### DIFF
--- a/amplify/backend/auth/teamtasksf9538190/teamtasksf9538190-cloudformation-template.yml
+++ b/amplify/backend/auth/teamtasksf9538190/teamtasksf9538190-cloudformation-template.yml
@@ -305,7 +305,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -431,7 +431,7 @@ Resources:
 
 
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -560,7 +560,7 @@ Resources:
             - '} '
 
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -659,7 +659,7 @@ Resources:
             - '}'
 
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify/backend/function/teamtasksf9538190PreSignup/teamtasksf9538190PreSignup-cloudformation-template.json
+++ b/amplify/backend/function/teamtasksf9538190PreSignup/teamtasksf9538190PreSignup-cloudformation-template.json
@@ -105,7 +105,7 @@
 						"Arn"
 					]
 				},
-				"Runtime": "nodejs8.10",
+				"Runtime": "nodejs10.x",
 				"Timeout": "25",
 				"Code": {
 					"S3Bucket": "teamtasks-dev-20190829222550-deployment",


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #3 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
