### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/amplify/backend/auth/teamtasksf9538190/teamtasksf9538190-cloudformation-template.yml
+++ b/amplify/backend/auth/teamtasksf9538190/teamtasksf9538190-cloudformation-template.yml
@@ -305,7 +305,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -431,7 +431,7 @@ Resources:
 
 
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -560,7 +560,7 @@ Resources:
             - '} '
 
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -659,7 +659,7 @@ Resources:
             - '}'
 
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify/backend/function/teamtasksf9538190PreSignup/teamtasksf9538190PreSignup-cloudformation-template.json
+++ b/amplify/backend/function/teamtasksf9538190PreSignup/teamtasksf9538190PreSignup-cloudformation-template.json
@@ -105,7 +105,7 @@
 						"Arn"
 					]
 				},
-				"Runtime": "nodejs10.x",
+				"Runtime": "nodejs14.x",
 				"Timeout": "25",
 				"Code": {
 					"S3Bucket": "teamtasks-dev-20190829222550-deployment",


### PR DESCRIPTION
CloudFormation templates in aws-amplify-team-task-tracking have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.